### PR TITLE
Update the ice36b brew patch 

### DIFF
--- a/Formula/ice36b.rb
+++ b/Formula/ice36b.rb
@@ -22,7 +22,7 @@ class Ice36b < Formula
 
   patch do
     url "https://raw.githubusercontent.com/ZeroC-Inc/homebrew-ice/master/Patches/ice-3.6b.brew.patch"
-    sha1 "b7095ae1d192754908d0b6c0b7edb2a7511abea5"
+    sha1 "ed9edb61583ae8b9d72070b086147bbb8a557ade"
   end
 
   def install

--- a/Patches/ice-3.6b.brew.patch
+++ b/Patches/ice-3.6b.brew.patch
@@ -1,6 +1,6 @@
 diff -r -c -N ../Ice-3.6b.orig/config/Make.common.rules ./config/Make.common.rules
 *** ../Ice-3.6b.orig/config/Make.common.rules	2014-12-15 04:34:51.000000000 -0330
---- ./config/Make.common.rules	2015-02-10 15:34:26.000000000 -0330
+--- ./config/Make.common.rules	2015-02-25 09:56:18.000000000 -0330
 ***************
 *** 1,6 ****
   # **********************************************************************
@@ -291,7 +291,7 @@ diff -r -c -N ../Ice-3.6b.orig/config/Make.common.rules ./config/Make.common.rul
   	fi
 diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules ./cpp/config/Make.rules
 *** ../Ice-3.6b.orig/cpp/config/Make.rules	2014-12-15 04:34:53.000000000 -0330
---- ./cpp/config/Make.rules	2015-02-10 15:34:37.000000000 -0330
+--- ./cpp/config/Make.rules	2015-02-25 09:56:31.000000000 -0330
 ***************
 *** 199,212 ****
   include	 $(top_srcdir)/config/Make.rules.$(UNAME)
@@ -342,7 +342,7 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules ./cpp/config/Make.rules
               LDFLAGS = $(LDPLATFORMFLAGS) $(CXXFLAGS) -L$(ice_dir)/$(libsubdir)$(cpp11libdirsuffix)
 diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules.Darwin ./cpp/config/Make.rules.Darwin
 *** ../Ice-3.6b.orig/cpp/config/Make.rules.Darwin	2014-12-15 04:34:51.000000000 -0330
---- ./cpp/config/Make.rules.Darwin	2015-02-10 15:34:26.000000000 -0330
+--- ./cpp/config/Make.rules.Darwin	2015-02-25 09:56:18.000000000 -0330
 ***************
 *** 69,75 ****
       #
@@ -362,7 +362,7 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules.Darwin ./cpp/config/Make.ru
   
 diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules.Linux ./cpp/config/Make.rules.Linux
 *** ../Ice-3.6b.orig/cpp/config/Make.rules.Linux	2014-12-15 04:34:51.000000000 -0330
---- ./cpp/config/Make.rules.Linux	2015-02-10 15:34:26.000000000 -0330
+--- ./cpp/config/Make.rules.Linux	2015-02-25 09:56:18.000000000 -0330
 ***************
 *** 112,118 ****
           #
@@ -380,9 +380,29 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/config/Make.rules.Linux ./cpp/config/Make.rul
               RPATH_DIR =
           endif
   
+diff -r -c -N ../Ice-3.6b.orig/cpp/include/Slice/Util.h ./cpp/include/Slice/Util.h
+*** ../Ice-3.6b.orig/cpp/include/Slice/Util.h	2014-12-15 04:34:52.000000000 -0330
+--- ./cpp/include/Slice/Util.h	2015-02-25 09:56:20.000000000 -0330
+***************
+*** 27,33 ****
+  SLICE_API void emitRaw(const char*);
+  SLICE_API std::vector<std::string> filterMcppWarnings(const std::string&);
+  SLICE_API void printGeneratedHeader(IceUtilInternal::Output& out, const std::string&, const std::string& commentStyle = "//");
+! SLICE_API std::string normalizePath(const std::string&);
+  }
+  
+  #endif
+--- 27,33 ----
+  SLICE_API void emitRaw(const char*);
+  SLICE_API std::vector<std::string> filterMcppWarnings(const std::string&);
+  SLICE_API void printGeneratedHeader(IceUtilInternal::Output& out, const std::string&, const std::string& commentStyle = "//");
+! 
+  }
+  
+  #endif
 diff -r -c -N ../Ice-3.6b.orig/cpp/src/Glacier2/Makefile ./cpp/src/Glacier2/Makefile
 *** ../Ice-3.6b.orig/cpp/src/Glacier2/Makefile	2014-12-15 04:34:52.000000000 -0330
---- ./cpp/src/Glacier2/Makefile	2015-02-10 15:34:27.000000000 -0330
+--- ./cpp/src/Glacier2/Makefile	2015-02-25 09:56:20.000000000 -0330
 ***************
 *** 33,44 ****
   
@@ -412,7 +432,7 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/src/Glacier2/Makefile ./cpp/src/Glacier2/Make
   	$(call installprogram,$(ROUTER),$(DESTDIR)$(install_bindir))
 diff -r -c -N ../Ice-3.6b.orig/cpp/src/IceGrid/Makefile ./cpp/src/IceGrid/Makefile
 *** ../Ice-3.6b.orig/cpp/src/IceGrid/Makefile	2014-12-15 04:34:53.000000000 -0330
---- ./cpp/src/IceGrid/Makefile	2015-02-10 15:34:37.000000000 -0330
+--- ./cpp/src/IceGrid/Makefile	2015-02-25 09:56:32.000000000 -0330
 ***************
 *** 100,106 ****
   
@@ -459,7 +479,7 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/src/IceGrid/Makefile ./cpp/src/IceGrid/Makefi
   # parallel make.
 diff -r -c -N ../Ice-3.6b.orig/cpp/src/IcePatch2/Makefile ./cpp/src/IcePatch2/Makefile
 *** ../Ice-3.6b.orig/cpp/src/IcePatch2/Makefile	2014-12-15 04:34:52.000000000 -0330
---- ./cpp/src/IcePatch2/Makefile	2015-02-10 15:34:27.000000000 -0330
+--- ./cpp/src/IcePatch2/Makefile	2015-02-25 09:56:22.000000000 -0330
 ***************
 *** 30,36 ****
   
@@ -479,7 +499,7 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/src/IcePatch2/Makefile ./cpp/src/IcePatch2/Ma
   	rm -f $@
 diff -r -c -N ../Ice-3.6b.orig/cpp/src/IcePatch2Lib/Makefile ./cpp/src/IcePatch2Lib/Makefile
 *** ../Ice-3.6b.orig/cpp/src/IcePatch2Lib/Makefile	2014-12-15 04:34:52.000000000 -0330
---- ./cpp/src/IcePatch2Lib/Makefile	2015-02-10 15:34:27.000000000 -0330
+--- ./cpp/src/IcePatch2Lib/Makefile	2015-02-25 09:56:22.000000000 -0330
 ***************
 *** 27,35 ****
   
@@ -501,9 +521,339 @@ diff -r -c -N ../Ice-3.6b.orig/cpp/src/IcePatch2Lib/Makefile ./cpp/src/IcePatch2
   
   $(libdir)/$(LIBFILENAME): $(OBJS)
   	@mkdir -p $(dir $@)
+diff -r -c -N ../Ice-3.6b.orig/cpp/src/Slice/Parser.cpp ./cpp/src/Slice/Parser.cpp
+*** ../Ice-3.6b.orig/cpp/src/Slice/Parser.cpp	2014-12-15 04:34:52.000000000 -0330
+--- ./cpp/src/Slice/Parser.cpp	2015-02-25 09:56:22.000000000 -0330
+***************
+*** 9,15 ****
+  
+  #include <IceUtil/Functional.h>
+  #include <IceUtil/InputUtil.h>
+- #include <IceUtil/FileUtil.h>
+  #include <IceUtil/StringUtil.h>
+  #include <Slice/Parser.h>
+  #include <Slice/GrammarUtil.h>
+--- 9,14 ----
+***************
+*** 19,27 ****
+  
+  #ifdef _WIN32
+  #   include <io.h>
+- #else
+- #   include <climits>  // For PATH_MAX
+- #   include <unistd.h> // For readlink()
+  #endif
+  
+  using namespace std;
+--- 18,23 ----
+***************
+*** 5689,5744 ****
+      _currentLine++;
+  }
+  
+- #ifndef _WIN32
+- namespace
+- {
+- string
+- readLink(const string& orig)
+- {
+-     string result = orig;
+-     string::size_type beg = 0;
+-     string::size_type next = string::npos;
+-     do
+-     {
+-         string subpath;
+-         next = result.find('/', beg + 1);
+-         if(next == string::npos)
+-         {
+-             subpath = result;
+-         }
+-         else
+-         {
+-             subpath = result.substr(0, next);
+-         }
+- 
+-         char buf[PATH_MAX + 1];
+-         int len = static_cast<int>(readlink(subpath.c_str(), buf, sizeof(buf)));
+-         if(len > 0)
+-         {
+-             buf[len] = '\0';
+-             string linkpath = buf;
+-             if(!IceUtilInternal::isAbsolutePath(linkpath)) // Path relative to the location of the link
+-             {
+-                 string::size_type pos = subpath.rfind('/');
+-                 assert(pos != string::npos);
+-                 linkpath = subpath.substr(0, pos + 1) + linkpath;
+-             }
+-             result = normalizePath(linkpath) + (next != string::npos ? result.substr(next) : string());
+-             beg = 0;
+-             next = 0;
+-         }
+-         else
+-         {
+-             beg = next;
+-         }
+-     }
+-     while(next != string::npos);
+-     return result;
+- }
+- 
+- }
+- #endif
+- 
+  bool
+  Slice::Unit::scanPosition(const char* s)
+  {
+--- 5685,5690 ----
+***************
+*** 5784,5801 ****
+  
+      LineType type = File;
+  
+-     //
+-     // We need to compare the file targets as one could be a symbolic link.
+-     //
+- #ifndef _WIN32
+-     if(readLink(currentFile) == readLink(_topLevelFile))
+-     {
+-         currentFile = _topLevelFile;
+-     }
+- #endif
+- 
+      if(_currentLine == 0)
+!     {        
+          if(_currentIncludeLevel > 0 || currentFile != _topLevelFile)
+          {
+              type = Push;
+--- 5730,5737 ----
+  
+      LineType type = File;
+  
+      if(_currentLine == 0)
+!     {
+          if(_currentIncludeLevel > 0 || currentFile != _topLevelFile)
+          {
+              type = Push;
+diff -r -c -N ../Ice-3.6b.orig/cpp/src/Slice/Util.cpp ./cpp/src/Slice/Util.cpp
+*** ../Ice-3.6b.orig/cpp/src/Slice/Util.cpp	2014-12-15 04:34:52.000000000 -0330
+--- ./cpp/src/Slice/Util.cpp	2015-02-25 09:56:22.000000000 -0330
+***************
+*** 10,21 ****
+  #include <Slice/Util.h>
+  #include <IceUtil/FileUtil.h>
+  #include <IceUtil/StringUtil.h>
+  
+  using namespace std;
+  using namespace Slice;
+  
+  string
+! Slice::normalizePath(const string& path)
+  {
+      string result = path;
+  
+--- 10,29 ----
+  #include <Slice/Util.h>
+  #include <IceUtil/FileUtil.h>
+  #include <IceUtil/StringUtil.h>
++ #include <climits>
++ 
++ #ifndef _MSC_VER
++ #  include <unistd.h> // For readlink()
++ #endif
+  
+  using namespace std;
+  using namespace Slice;
+  
++ namespace
++ {
++ 
+  string
+! normalizePath(const string& path)
+  {
+      string result = path;
+  
+***************
+*** 71,79 ****
+--- 79,101 ----
+      return result;
+  }
+  
++ }
++ 
+  string
+  Slice::fullPath(const string& path)
+  {
++     //
++     // This function returns the canonicalized absolute pathname of
++     // the given path.
++     //
++     // It is used for instance used to normalize the paths provided
++     // with -I options. Like mcpp, we need to follow the symbolic
++     // links to ensure changeIncludes works correctly. For example, it
++     // must be possible to specify -I/opt/Ice-3.6 where Ice-3.6 is
++     // symbolic link to Ice-3.6.0 (if we don't do the same as mcpp,
++     // the generated headers will contain a full path...)
++     //
++ 
+      string result = path;
+      if(!IceUtilInternal::isAbsolutePath(result))
+      {
+***************
+*** 84,133 ****
+          }
+      }
+  
+!     return normalizePath(result);
+! }
+  
+! string
+! Slice::changeInclude(const string& orig, const vector<string>& includePaths)
+! {
+!     //
+!     // MCPP does not follow symlinks included files so we only
+!     // call fullPath on the base directory and not the file itself.
+!     //
+!     string file = orig;
+!     string::size_type pos;
+!     if((pos = orig.rfind('/')) != string::npos)
+      {
+!         string base = orig.substr(0, pos);
+!         file = fullPath(base) + orig.substr(pos);
+      }
+  
+      //
+      // Compare each include path against the included file and select
+      // the path that produces the shortest relative filename.
+      //
+!     string result = file;
+!     for(vector<string>::const_iterator p = includePaths.begin(); p != includePaths.end(); ++p)
+      {
+!         if(file.compare(0, p->length(), *p) == 0)
+!         {
+!             string s = file.substr(p->length() + 1); // + 1 for the '/'
+!             if(s.size() < result.size())
+              {
+!                 result = s;
+              }
+          }
+!     }
+! 
+!     if(result == file)
+!     {
+          //
+!         // Don't return a full path if we couldn't reduce the given path, instead
+!         // return the normalized given path.
+          //
+!         result = normalizePath(orig);
+      }
+  
+      if((pos = result.rfind('.')) != string::npos)
+      {
+          result.erase(pos);
+--- 106,205 ----
+          }
+      }
+  
+!     result = normalizePath(result);
+  
+! #ifdef _WIN32
+!     return result;
+! #else
+! 
+!     string::size_type beg = 0;
+!     string::size_type next;
+!     do
+      {
+!         string subpath;
+!         next = result.find('/', beg + 1);
+!         if(next == string::npos)
+!         {
+!             subpath = result;
+!         }
+!         else
+!         {
+!             subpath = result.substr(0, next);
+!         }
+! 
+!         char buf[PATH_MAX + 1];
+!         int len = static_cast<int>(readlink(subpath.c_str(), buf, sizeof(buf)));
+!         if(len > 0)
+!         {
+!             buf[len] = '\0';
+!             string linkpath = buf;
+!             if(!IceUtilInternal::isAbsolutePath(linkpath)) // Path relative to the location of the link
+!             {
+!                 string::size_type pos = subpath.rfind('/');
+!                 assert(pos != string::npos);
+!                 linkpath = subpath.substr(0, pos + 1) + linkpath;
+!             }
+!             result = normalizePath(linkpath) + (next != string::npos ? result.substr(next) : string());
+!             beg = 0;
+!             next = 0;
+!         }
+!         else
+!         {
+!             beg = next;
+!         }
+      }
++     while(next != string::npos);
++     return result;
++ #endif
++ }
+  
++ string
++ Slice::changeInclude(const string& path, const vector<string>& includePaths)
++ {
+      //
+      // Compare each include path against the included file and select
+      // the path that produces the shortest relative filename.
+      //
+!     string result = path;
+!     vector<string> paths;
+!     paths.push_back(path);
+!     //
+!     // if path is not a canonical path we also test with its canonical
+!     // path
+!     //
+!     string canonicalPath = fullPath(path);
+!     if(canonicalPath != path)
+      {
+!         paths.push_back(canonicalPath);
+!     }
+!     
+!     for(vector<string>::const_iterator i = paths.begin(); i != paths.end(); ++i)
+!     {
+!         for(vector<string>::const_iterator j = includePaths.begin(); j != includePaths.end(); ++j)
+!         {            
+!             if(i->compare(0, j->length(), *j) == 0)
+              {
+!                 string s = i->substr(j->length() + 1); // + 1 for the '/'
+!                 if(s.size() < result.size())
+!                 {
+!                     result = s;
+!                 }
+              }
+          }
+!         
+          //
+!         // If the path has been already shortened no need to test
+!         // with canonical path.
+          //
+!         if(result != path)
+!         {
+!             break;
+!         }
+      }
+  
++     result = normalizePath(result); // Normalize the result.
++ 
++     string::size_type pos;
+      if((pos = result.rfind('.')) != string::npos)
+      {
+          result.erase(pos);
 diff -r -c -N ../Ice-3.6b.orig/cs/config/Make.rules.cs ./cs/config/Make.rules.cs
 *** ../Ice-3.6b.orig/cs/config/Make.rules.cs	2014-12-15 04:34:52.000000000 -0330
---- ./cs/config/Make.rules.cs	2015-02-10 15:34:29.000000000 -0330
+--- ./cs/config/Make.rules.cs	2015-02-25 09:56:24.000000000 -0330
 ***************
 *** 89,95 ****
   
@@ -540,7 +890,7 @@ diff -r -c -N ../Ice-3.6b.orig/cs/config/Make.rules.cs ./cs/config/Make.rules.cs
       ifdef ice_src_dist
 diff -r -c -N ../Ice-3.6b.orig/php/config/Make.rules.php ./php/config/Make.rules.php
 *** ../Ice-3.6b.orig/php/config/Make.rules.php	2014-12-15 04:34:52.000000000 -0330
---- ./php/config/Make.rules.php	2015-02-10 15:34:34.000000000 -0330
+--- ./php/config/Make.rules.php	2015-02-25 09:56:31.000000000 -0330
 ***************
 *** 107,113 ****
   endif
@@ -561,7 +911,7 @@ diff -r -c -N ../Ice-3.6b.orig/php/config/Make.rules.php ./php/config/Make.rules
   else
 diff -r -c -N ../Ice-3.6b.orig/py/config/Make.rules ./py/config/Make.rules
 *** ../Ice-3.6b.orig/py/config/Make.rules	2014-12-15 04:34:52.000000000 -0330
---- ./py/config/Make.rules	2015-02-10 15:34:35.000000000 -0330
+--- ./py/config/Make.rules	2015-02-25 09:56:31.000000000 -0330
 ***************
 *** 47,65 ****
   
@@ -672,7 +1022,7 @@ diff -r -c -N ../Ice-3.6b.orig/py/config/Make.rules ./py/config/Make.rules
   ifeq ($(UNAME),SunOS)
 diff -r -c -N ../Ice-3.6b.orig/rb/config/Make.rules ./rb/config/Make.rules
 *** ../Ice-3.6b.orig/rb/config/Make.rules	2014-12-15 04:34:53.000000000 -0330
---- ./rb/config/Make.rules	2015-02-10 15:34:36.000000000 -0330
+--- ./rb/config/Make.rules	2015-02-25 09:56:31.000000000 -0330
 ***************
 *** 144,150 ****
   install_libdir		= $(prefix)/ruby


### PR DESCRIPTION
This updates the ice36b brew patch to fix the bug described in
https://www.zeroc.com/forums/help-center/3797-slice2cpp-constructs-absolute-paths-include.html